### PR TITLE
Add Release GitHub action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
                   "labels": []
                 }
               ],
-              "template": "#{{CHANGELOG}}",
+              "template": "#{{CHANGELOG}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
               "pr_template": "- #{{TITLE}} (PR ##{{NUMBER}}) by @#{{AUTHOR}}",
               "max_pull_requests": 100,
               "max_back_track_time_days": 180


### PR DESCRIPTION
- Add Release GitHub action to automatically build a release (with artifact) when a PR is merged into branch `master`